### PR TITLE
Put resource labels on replica-binary for root vol

### DIFF
--- a/driver/docker-compose.yml.tmpl
+++ b/driver/docker-compose.yml.tmpl
@@ -33,13 +33,13 @@ replica:
         io.rancher.container.hostname_override: container_name
         io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
         io.rancher.scheduler.affinity:container_soft: $DRIVER_CONTAINER
-        {{- if (and (ne .SizeGB "0") (ne .SizeGB "")) }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .SizeGB "0") (ne .SizeGB "")) }}
         io.rancher.resource.disksize.{{.Name}}: {{.SizeGB}}
         {{- end}}
-        {{- if (ne .ReadIOPS "") }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .ReadIOPS "")) }}
         io.rancher.resource.read_iops.{{.Name}}: {{.ReadIOPS}}
         {{- end}}
-        {{- if (ne .WriteIOPS "") }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .WriteIOPS "")) }}
         io.rancher.resource.write_iops.{{.Name}}: {{.WriteIOPS}}
         {{- end}}
     metadata:
@@ -69,6 +69,15 @@ replica-binary:
     - /cmd
     labels:
         io.rancher.container.start_once: true
+        {{- if (and (ne .SizeGB "0") (ne .SizeGB "")) }}
+        io.rancher.resource.disksize.{{.Name}}: {{.SizeGB}}
+        {{- end}}
+        {{- if (ne .ReadIOPS "") }}
+        io.rancher.resource.read_iops.{{.Name}}: {{.ReadIOPS}}
+        {{- end}}
+        {{- if (ne .WriteIOPS "") }}
+        io.rancher.resource.write_iops.{{.Name}}: {{.WriteIOPS}}
+        {{- end}}
 {{- end}}
 
 sync-agent:

--- a/driver/template.go
+++ b/driver/template.go
@@ -37,13 +37,13 @@ replica:
         io.rancher.container.hostname_override: container_name
         io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
         io.rancher.scheduler.affinity:container_soft: $DRIVER_CONTAINER
-        {{- if (and (ne .SizeGB "0") (ne .SizeGB "")) }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .SizeGB "0") (ne .SizeGB "")) }}
         io.rancher.resource.disksize.{{.Name}}: {{.SizeGB}}
         {{- end}}
-        {{- if (ne .ReadIOPS "") }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .ReadIOPS "")) }}
         io.rancher.resource.read_iops.{{.Name}}: {{.ReadIOPS}}
         {{- end}}
-        {{- if (ne .WriteIOPS "") }}
+        {{- if (and (eq .ReplicaBaseImage "") (ne .WriteIOPS "")) }}
         io.rancher.resource.write_iops.{{.Name}}: {{.WriteIOPS}}
         {{- end}}
     metadata:
@@ -73,6 +73,15 @@ replica-binary:
     - /cmd
     labels:
         io.rancher.container.start_once: true
+        {{- if (and (ne .SizeGB "0") (ne .SizeGB "")) }}
+        io.rancher.resource.disksize.{{.Name}}: {{.SizeGB}}
+        {{- end}}
+        {{- if (ne .ReadIOPS "") }}
+        io.rancher.resource.read_iops.{{.Name}}: {{.ReadIOPS}}
+        {{- end}}
+        {{- if (ne .WriteIOPS "") }}
+        io.rancher.resource.write_iops.{{.Name}}: {{.WriteIOPS}}
+        {{- end}}
 {{- end}}
 
 sync-agent:

--- a/driver/template_test.go
+++ b/driver/template_test.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -17,6 +18,13 @@ func TestTemplateParses(t *testing.T) {
 	if err := composeTemplate.Execute(dockerCompose, volConf); err != nil {
 		t.Fatalf("Error while executing template %v", err)
 	}
+	fmt.Printf("%s", dockerCompose)
 
-	// fmt.Printf("%s", dockerCompose)
+	fmt.Println("\n\n-----------\b\b")
+	volConf.ReplicaBaseImage = ""
+	dockerCompose = new(bytes.Buffer)
+	if err := composeTemplate.Execute(dockerCompose, volConf); err != nil {
+		t.Fatalf("Error while executing template %v", err)
+	}
+	fmt.Printf("%s", dockerCompose)
 }


### PR DESCRIPTION
When we create a volume with a backing file, we add a replica-binary
container from which the replica does a volumes_from. Rancher schedules
containers that are the target of a volumes_from first when scheduling a
deployment unit. Normally, scheduling labels are copied amongst all
containers in a deployment unit, so deployment order doesn't matter.

But these resource labels are purposefully not scheduling labels so that
they do not get copied to all containers and thus throw the resource
based scheduler off.

So with these labels, order matters and they must be on the first
container in the deployment unit to get deployed. So, this change puts
the labels on the replica-binary container instead of the replica
container when it is present.