### PR TITLE
Increase timeouts

### DIFF
--- a/driver/docker-compose.yml.tmpl
+++ b/driver/docker-compose.yml.tmpl
@@ -53,8 +53,6 @@ replica:
         port: 8199
         request_line: GET /replica/status HTTP/1.0
         response_timeout: 50000
-        initializing_timeout: 60000
-        reinitializing_timeout: 60000
         strategy: recreateOnQuorum
         recreate_on_quorum_strategy_config:
             quorum: 1

--- a/driver/stack.go
+++ b/driver/stack.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	retryInterval          = 2 * time.Second
-	retryMax               = 200
+	retryMax               = 1800
 	composeAffinityLabel   = "io.rancher.scheduler.affinity:container"
 	composeVolumeName      = "VOLUME_NAME"
 	composeVolumeSize      = "VOLUME_SIZE"

--- a/driver/template.go
+++ b/driver/template.go
@@ -57,8 +57,6 @@ replica:
         port: 8199
         request_line: GET /replica/status HTTP/1.0
         response_timeout: 50000
-        initializing_timeout: 60000
-        reinitializing_timeout: 60000
         strategy: recreateOnQuorum
         recreate_on_quorum_strategy_config:
             quorum: 1

--- a/driver/wait.go
+++ b/driver/wait.go
@@ -9,7 +9,7 @@ import (
 )
 
 func WaitFor(client *rancherClient.RancherClient, resource *rancherClient.Resource, output interface{}, transitioning func() string) error {
-	return util.Backoff(5*time.Minute, fmt.Sprintf("Failed waiting for %s:%s", resource.Type, resource.Id), func() (bool, error) {
+	return util.Backoff(60*time.Minute, fmt.Sprintf("Failed waiting for %s:%s", resource.Type, resource.Id), func() (bool, error) {
 		err := client.Reload(resource, output)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Wait much longer for stacks and services to become active and remove
replica initialization timeouts all together.