### PR TITLE
Fix restore error

### DIFF
--- a/cattleevents/listener.go
+++ b/cattleevents/listener.go
@@ -92,6 +92,11 @@ func decodeEvent(event *revents.Event, key string, target interface{}) error {
 	return fmt.Errorf("Event doesn't contain %v data. Event: %#v.", key, event)
 }
 
+type processData struct {
+	ProcessID  string `mapstructure:"processId"`
+	VolumeName string
+}
+
 type eventBackup struct {
 	UUID         string
 	URI          string

--- a/cattleevents/volume_client.go
+++ b/cattleevents/volume_client.go
@@ -13,7 +13,11 @@ import (
 )
 
 func newVolumeClient(snapshot *eventSnapshot) *volumeClient {
-	url := fmt.Sprintf("http://controller.%v.rancher.internal/v1", util.VolumeToStackName(snapshot.Volume.Name))
+	return newVolumeClientFromName(snapshot.Volume.Name)
+}
+
+func newVolumeClientFromName(volumeName string) *volumeClient {
+	url := fmt.Sprintf("http://controller.%v.rancher.internal/v1", util.VolumeToStackName(volumeName))
 	return &volumeClient{
 		baseURL: url,
 	}

--- a/cattleevents/volume_handlers.go
+++ b/cattleevents/volume_handlers.go
@@ -49,12 +49,17 @@ func (h *volumeHandlers) RestoreFromBackup(event *revents.Event, cli *client.Ran
 		return err
 	}
 
-	volClient := newVolumeClient(&backup.Snapshot)
+	pd := &processData{}
+	if err = decodeEvent(event, "processData", pd); err != nil {
+		return err
+	}
+
+	volClient := newVolumeClientFromName(pd.VolumeName)
 
 	logrus.Infof("Restoring from backup %v", backup.UUID)
 
 	target := newBackupTarget(backup)
-	status, err := volClient.restoreFromBackup(backup.UUID, backup.URI, target)
+	status, err := volClient.restoreFromBackup(pd.ProcessID, backup.URI, target)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Pass the process id as the identifier for the restore process so that
it can be uniquely identified if the restore is retried. Also use an
explicit volumeName parameter for constructing the volume api URL. This
is necessary because the volume embedded inside backup is where the
backup originated but the target of the restore may be a different
volume.